### PR TITLE
fix(tsconfig): switch to NodeNext and set rootDir for TS 6 compat

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,9 @@
 {
   "compilerOptions": {
-    "module": "ESNext",
+    "module": "NodeNext",
     "target": "ES2022",
-    "moduleResolution": "Node",
+    "moduleResolution": "NodeNext",
+    "rootDir": "src",
     "removeComments": true,
     "alwaysStrict": true,
     "noImplicitAny": true,


### PR DESCRIPTION
TypeScript 6 deprecates `moduleResolution: Node` and now requires an explicit `rootDir` when `outDir` is set.

- Switch `module` and `moduleResolution` to `NodeNext` (existing imports already use `.js` extensions, so no code changes needed)
- Add `rootDir: src`