### PR TITLE
fix: include node types and narrow argv access for TS 6

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -13,7 +13,7 @@ const releaseTypes = ["major", "premajor", "minor", "preminor", "patch", "prepat
 
 function printUsage() {
     logger.info(
-        `Usage: ${path.basename(process.argv[1])} [package.json] [${
+        `Usage: ${path.basename(process.argv[1]!)} [package.json] [${
             releaseTypes.reduce((previousValue, currentValue): string => {
                 return previousValue + " | " + currentValue;
             })
@@ -35,7 +35,7 @@ async function main() {
         process.exit(1);
     }
 
-    const releaseTypeString = process.argv[3];
+    const releaseTypeString = process.argv[3]!;
     const releaseType = toReleaseType(releaseTypeString);
     if (releaseType === undefined) {
         logger.error(`Invalid release type: ${releaseTypeString}`);
@@ -43,7 +43,7 @@ async function main() {
         process.exit(1);
     }
 
-    const packageJSONFilePath = process.argv[2];
+    const packageJSONFilePath = process.argv[2]!;
 
     logger.info(`Using package.json file: ${packageJSONFilePath}`);
     logger.info(`Will bump semver by: ${releaseType}`);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "target": "ES2022",
     "moduleResolution": "NodeNext",
     "rootDir": "src",
+    "types": ["node"],
     "removeComments": true,
     "alwaysStrict": true,
     "noImplicitAny": true,


### PR DESCRIPTION
TypeScript 6 stops auto-discovering `@types/node` under `NodeNext` resolution, and indexed access on `process.argv` now propagates `undefined` through `noUncheckedIndexedAccess`.

- Add `types: ["node"]` to `tsconfig.json` so node builtins (and chalk's vendored `node:tty` reference) resolve
- Non-null assert `process.argv[1]`, `process.argv[2]`, `process.argv[3]` (length is already validated, and argv[1] is always present for a script)